### PR TITLE
fix) LimitExceededException in Amplify Auth ConfirmSignUp mail

### DIFF
--- a/src/components/RegisterForm/RegisterForm.jsx
+++ b/src/components/RegisterForm/RegisterForm.jsx
@@ -127,7 +127,6 @@ const RegisterForm = ({ setRegisterSuccess }) => {
       });
     })
     .catch(err => {
-      //alert("인증 코드가 일치하지 않습니다!"); 
       setAlertType("notCorrespond");
       updateFormState(() => ({ ...formState, formType: "confirmSignUp" }));
     })
@@ -136,8 +135,11 @@ const RegisterForm = ({ setRegisterSuccess }) => {
 
   async function resendSignUp() {
     const { username } = formState;
-    await Auth.resendSignUp(username);
     setAlertType("resend");
+    Auth.resendSignUp(username)
+    .catch(err => {
+      alert("수상한 행동이 감지되어 일정 시간 동안 재전송이 불가능합니다.")
+    })
   }
 
   return (

--- a/src/style/_Forgot.scss
+++ b/src/style/_Forgot.scss
@@ -42,3 +42,30 @@
     margin-top: 1.5rem;
   }
   
+  .register-form__container {
+    display: flex;
+    input {
+      flex: 9;
+    }
+    button {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin-top: 0 !important;
+      background-color: #40368a;
+      height: calc(1.5em + 0.75rem + 2px);
+      margin-left: 1.5rem;
+      padding: 1.5rem 0;
+      flex: 1;
+    }
+  }
+  
+  .register-form__comment {
+    display: inline-block;
+    font-size: 1rem;
+    div {
+      margin-top: 0.5rem;
+      font-weight: 600;
+    }
+  }
+  


### PR DESCRIPTION
 테스트하는 과정에서 한 계정에 인증 메일을 계속 보냈더니 더 이상 메일이 가지 않는 상황이 발생해서 찾아본 결과 짧은 시간에 10번 정도 메일을 재전송하면 LimitExceededException 오류가 발생하는 것을 확인해볼 수 있었다.
-> 어느정도 시간이 지나면 다시 원상복구되는 것을 확인하였고, 이와 같은 상황은 해킹이 의심되는 상황이라 판단하여 경고 알람창을 띄우도록 하였습니다.

![image](https://user-images.githubusercontent.com/52690419/119428104-3f76a580-bd47-11eb-862e-93fcb85e4097.png)







